### PR TITLE
Derive keypair from mnemonic seed instead of entropy

### DIFF
--- a/src/account.js
+++ b/src/account.js
@@ -40,11 +40,11 @@ export class Account extends React.Component {
   }
 
   createAccount() {
-    this.props.store.createAccountFromSeed(this.state.generatedPhrase);
+    this.props.store.createAccountFromMnemonic(this.state.generatedPhrase);
   }
 
   recoverAccount() {
-    this.props.store.createAccountFromSeed(this.state.recoveredPhrase);
+    this.props.store.createAccountFromMnemonic(this.state.recoveredPhrase);
   }
 
   onModeChange(walletMode) {

--- a/src/store.js
+++ b/src/store.js
@@ -33,9 +33,9 @@ export class Store {
     await this._lf.setItem('accountSecretKey', this.accountSecretKey);
   }
 
-  async createAccountFromSeed(seedPhrase) {
-    const seed = Buffer.from(bip39.mnemonicToEntropy(seedPhrase));
-    const keyPair = nacl.sign.keyPair.fromSeed(seed);
+  async createAccountFromMnemonic(mnemonic) {
+    const seed = await bip39.mnemonicToSeed(mnemonic);
+    const keyPair = nacl.sign.keyPair.fromSeed(seed.slice(0, 32));
     this.accountSecretKey = keyPair.secretKey;
     this._ee.emit('change');
     await this._lf.setItem('accountSecretKey', keyPair.secretKey);


### PR DESCRIPTION
Entropy should not be used for deriving keypairs. This change will break anyone's saved mnemonic phrase but should be fine since we're still testnet. This approach allows using the same mnemonic phrase from `solana-keygen` to recover an account.